### PR TITLE
Support for base64 shortcut icons

### DIFF
--- a/packages/quick_actions/quick_actions_android/android/src/main/java/io/flutter/plugins/quickactions/Messages.java
+++ b/packages/quick_actions/quick_actions_android/android/src/main/java/io/flutter/plugins/quickactions/Messages.java
@@ -101,6 +101,17 @@ public class Messages {
       this.icon = setterArg;
     }
 
+    /** Base64-encoded string representing the icon image. */
+    private @Nullable String base64Icon;
+
+    public @Nullable String getBase64Icon() {
+      return base64Icon;
+    }
+
+    public void setBase64Icon(@Nullable String setterArg) {
+      this.base64Icon = setterArg;
+    }
+
     /** Constructor is non-public to enforce null safety; use Builder. */
     ShortcutItemMessage() {}
 
@@ -127,21 +138,30 @@ public class Messages {
         return this;
       }
 
+      private @Nullable String base64Icon;
+
+      public @NonNull Builder setBase64Icon(@Nullable String setterArg) {
+        this.base64Icon = setterArg;
+        return this;
+      }
+
       public @NonNull ShortcutItemMessage build() {
         ShortcutItemMessage pigeonReturn = new ShortcutItemMessage();
         pigeonReturn.setType(type);
         pigeonReturn.setLocalizedTitle(localizedTitle);
         pigeonReturn.setIcon(icon);
+        pigeonReturn.setBase64Icon(base64Icon);
         return pigeonReturn;
       }
     }
 
     @NonNull
     ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<Object>(3);
+      ArrayList<Object> toListResult = new ArrayList<Object>(4);
       toListResult.add(type);
       toListResult.add(localizedTitle);
       toListResult.add(icon);
+      toListResult.add(base64Icon);
       return toListResult;
     }
 
@@ -153,6 +173,8 @@ public class Messages {
       pigeonResult.setLocalizedTitle((String) localizedTitle);
       Object icon = list.get(2);
       pigeonResult.setIcon((String) icon);
+      Object base64Icon = list.get(3);
+      pigeonResult.setBase64Icon((String) base64Icon);
       return pigeonResult;
     }
   }

--- a/packages/quick_actions/quick_actions_android/android/src/main/java/io/flutter/plugins/quickactions/QuickActions.java
+++ b/packages/quick_actions/quick_actions_android/android/src/main/java/io/flutter/plugins/quickactions/QuickActions.java
@@ -28,9 +28,9 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.Base64;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.util.Base64;
 
 final class QuickActions implements AndroidQuickActionsApi {
   protected static final String EXTRA_ACTION = "some unique action key";
@@ -62,12 +62,10 @@ final class QuickActions implements AndroidQuickActionsApi {
   @Override
   public void setShortcutItems(
       @NonNull List<ShortcutItemMessage> itemsList, @NonNull Result<Void> result) {
-        System.out.println("MD2222 - Helllooooo");
     if (!isVersionAllowed()) {
       result.success(null);
       return;
     }
-    System.out.println("MD2222 - 1111");
     List<ShortcutInfoCompat> shortcuts = shortcutItemMessageToShortcutInfo(itemsList);
     Executor uiThreadExecutor = new UiThreadExecutor();
     ThreadPoolExecutor executor = new ThreadPoolExecutor(0, 1, 1, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
@@ -132,7 +130,6 @@ final class QuickActions implements AndroidQuickActionsApi {
   private List<ShortcutInfoCompat> shortcutItemMessageToShortcutInfo(
       @NonNull List<ShortcutItemMessage> shortcuts) {
     final List<ShortcutInfoCompat> shortcutInfos = new ArrayList<>();
-
     for (ShortcutItemMessage shortcut : shortcuts) {
       final String icon = shortcut.getIcon();
       final String base64Icon = shortcut.getBase64Icon();
@@ -141,19 +138,14 @@ final class QuickActions implements AndroidQuickActionsApi {
       final ShortcutInfoCompat.Builder shortcutBuilder = new ShortcutInfoCompat.Builder(context, type);
 
       final Intent intent = getIntentToOpenMainActivity(type);
-      System.out.println("MD2222 - Helllooooo");
       if (icon != null && !icon.isEmpty()) {
-        // Load normal icon if it exists
         final int resourceId = loadResourceId(context, icon);
         if (resourceId > 0) {
           shortcutBuilder.setIcon(IconCompat.createWithResource(context, resourceId));
         }
       } else if (base64Icon != null && !base64Icon.isEmpty()) {
-        // Load base64 image if icon is null
-
-        byte[] decodedString = android.util.Base64.decode(base64Icon, android.util.Base64.DEFAULT);
+        byte[] decodedString = Base64.getDecoder().decode(base64Icon);
         Bitmap bitmap = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
-        System.out.println("MD2222 - Hellloooo 3332 2 2 2 o");
         if (bitmap != null) {
           shortcutBuilder.setIcon(IconCompat.createWithBitmap(bitmap));
         }

--- a/packages/quick_actions/quick_actions_android/lib/quick_actions_android.dart
+++ b/packages/quick_actions/quick_actions_android/lib/quick_actions_android.dart
@@ -52,6 +52,7 @@ class QuickActionsAndroid extends QuickActionsPlatform {
       type: item.type,
       localizedTitle: item.localizedTitle,
       icon: item.icon,
+      base64Icon: item.base64Icon,
     );
   }
 }

--- a/packages/quick_actions/quick_actions_android/lib/src/messages.g.dart
+++ b/packages/quick_actions/quick_actions_android/lib/src/messages.g.dart
@@ -17,6 +17,7 @@ class ShortcutItemMessage {
     required this.type,
     required this.localizedTitle,
     this.icon,
+    this.base64Icon,
   });
 
   /// The identifier of this item; should be unique within the app.
@@ -28,11 +29,16 @@ class ShortcutItemMessage {
   /// Name of native resource to be displayed as the icon for this item.
   String? icon;
 
+  /// Name of native resource to be displayed as the icon for this item.
+  String? base64Icon;
+
+
   Object encode() {
     return <Object?>[
       type,
       localizedTitle,
       icon,
+      base64Icon,
     ];
   }
 
@@ -42,6 +48,7 @@ class ShortcutItemMessage {
       type: result[0]! as String,
       localizedTitle: result[1]! as String,
       icon: result[2] as String?,
+      base64Icon: result[3] as String?,
     );
   }
 }

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -5,8 +5,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 1.0.18
 
 environment:
-  sdk: ^3.5.0
-  flutter: ">=3.24.0"
+  sdk: ^3.4.0
+  flutter: ">=3.22.0"
 
 flutter:
   plugin:

--- a/packages/quick_actions/quick_actions_ios/ios/quick_actions_ios/Sources/quick_actions_ios/messages.g.swift
+++ b/packages/quick_actions/quick_actions_ios/ios/quick_actions_ios/Sources/quick_actions_ios/messages.g.swift
@@ -85,6 +85,8 @@ struct ShortcutItemMessage {
   var localizedSubtitle: String? = nil
   /// Name of native resource to be displayed as the icon for this item.
   var icon: String? = nil
+  /// Base64-encoded icon for this item.
+  var iconBase64: String? = nil
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ __pigeon_list: [Any?]) -> ShortcutItemMessage? {
@@ -92,12 +94,14 @@ struct ShortcutItemMessage {
     let localizedTitle = __pigeon_list[1] as! String
     let localizedSubtitle: String? = nilOrValue(__pigeon_list[2])
     let icon: String? = nilOrValue(__pigeon_list[3])
+    let iconBase64: String? = nilOrValue(__pigeon_list[4])
 
     return ShortcutItemMessage(
       type: type,
       localizedTitle: localizedTitle,
       localizedSubtitle: localizedSubtitle,
-      icon: icon
+      icon: icon,
+      iconBase64: iconBase64
     )
   }
   func toList() -> [Any?] {
@@ -106,6 +110,7 @@ struct ShortcutItemMessage {
       localizedTitle,
       localizedSubtitle,
       icon,
+      iconBase64,
     ]
   }
 }

--- a/packages/quick_actions/quick_actions_ios/lib/messages.g.dart
+++ b/packages/quick_actions/quick_actions_ios/lib/messages.g.dart
@@ -36,6 +36,7 @@ class ShortcutItemMessage {
     required this.localizedTitle,
     this.localizedSubtitle,
     this.icon,
+    this.base64Icon,
   });
 
   /// The identifier of this item; should be unique within the app.
@@ -50,12 +51,19 @@ class ShortcutItemMessage {
   /// Name of native resource to be displayed as the icon for this item.
   String? icon;
 
+  /// Base64-encoded string representing the icon image.
+  ///
+  /// This is an alternative to [icon]. Only one of [icon] or [base64Icon]
+  /// should be provided.
+  final String? base64Icon;
+
   Object encode() {
     return <Object?>[
       type,
       localizedTitle,
       localizedSubtitle,
       icon,
+      base64Icon,
     ];
   }
 
@@ -66,6 +74,7 @@ class ShortcutItemMessage {
       localizedTitle: result[1]! as String,
       localizedSubtitle: result[2] as String?,
       icon: result[3] as String?,
+      base64Icon: result[4] as String?,
     );
   }
 }

--- a/packages/quick_actions/quick_actions_ios/lib/quick_actions_ios.dart
+++ b/packages/quick_actions/quick_actions_ios/lib/quick_actions_ios.dart
@@ -49,6 +49,7 @@ class QuickActionsIos extends QuickActionsPlatform {
       localizedTitle: item.localizedTitle,
       localizedSubtitle: item.localizedSubtitle,
       icon: item.icon,
+      base64Icon: item.base64Icon,
     );
   }
 }

--- a/packages/quick_actions/quick_actions_ios/pigeons/messages.dart
+++ b/packages/quick_actions/quick_actions_ios/pigeons/messages.dart
@@ -17,6 +17,7 @@ class ShortcutItemMessage {
     this.localizedTitle,
     this.localizedSubtitle,
     this.icon,
+    this.base64Icon,
   );
 
   /// The identifier of this item; should be unique within the app.
@@ -30,6 +31,9 @@ class ShortcutItemMessage {
 
   /// Name of native resource to be displayed as the icon for this item.
   String? icon;
+
+  /// Base64-encoded icon for this item.
+  String? base64Icon;
 }
 
 @HostApi()

--- a/packages/quick_actions/quick_actions_platform_interface/lib/method_channel/method_channel_quick_actions.dart
+++ b/packages/quick_actions/quick_actions_platform_interface/lib/method_channel/method_channel_quick_actions.dart
@@ -48,6 +48,7 @@ class MethodChannelQuickActions extends QuickActionsPlatform {
       if (item.localizedSubtitle != null)
         'localizedSubtitle': item.localizedSubtitle,
       'icon': item.icon,
+      'base64Icon': item.base64Icon,
     };
   }
 }

--- a/packages/quick_actions/quick_actions_platform_interface/lib/types/shortcut_item.dart
+++ b/packages/quick_actions/quick_actions_platform_interface/lib/types/shortcut_item.dart
@@ -13,6 +13,7 @@ class ShortcutItem {
     required this.localizedTitle,
     this.localizedSubtitle,
     this.icon,
+    this.base64Icon,
   });
 
   /// The identifier of this item; should be unique within the app.
@@ -29,4 +30,10 @@ class ShortcutItem {
   /// Name of native resource (xcassets etc; NOT a Flutter asset) to be
   /// displayed as the icon for this item.
   final String? icon;
+
+  /// Base64-encoded string representing the icon image.
+  ///
+  /// This is an alternative to [icon]. Only one of [icon] or [base64Icon]
+  /// should be provided.
+  final String? base64Icon;
 }


### PR DESCRIPTION
Added support for base64 images on Android devices and almost for iOS. 😅
- Unfortunately, UIApplicationShortcutIcon on iOS does not support custom image files; the images need to be pre-built and included in the app bundle.